### PR TITLE
fixed a problem with join() at Test::Output::Tie::PRINT()

### DIFF
--- a/lib/Test/Output/Tie.pm
+++ b/lib/Test/Output/Tie.pm
@@ -44,7 +44,7 @@ This method is called each time STDERR or STDOUT are printed to.
 
 sub PRINT {
     my $self = shift;
-    $$self .= join(':::s', @_);
+    $$self .= join(defined $, ? $, : '', @_);
     $$self .= defined $\ ? $\ : ''; # for say()
 }
 

--- a/t/stderr_is.t
+++ b/t/stderr_is.t
@@ -1,5 +1,5 @@
 use Test::Tester;
-use Test::More tests => 28;
+use Test::More tests => 42;
 use Test::Output;
 
 use strict;
@@ -8,6 +8,35 @@ use warnings;
 check_test( sub {
             stderr_is(sub {
                         print STDERR "TEST OUT\n";
+                      },
+                      "TEST OUT\n",
+                      'Testing STDERR'
+                    )
+            },{
+              ok => 1,
+              name => 'Testing STDERR',
+              diag => '',
+            },'STDERR matching success'
+          );
+
+check_test( sub {
+            stderr_is(sub {
+                        print STDERR "TEST", " ", "OUT", "\n";
+                      },
+                      "TEST OUT\n",
+                      'Testing STDERR'
+                    )
+            },{
+              ok => 1,
+              name => 'Testing STDERR',
+              diag => '',
+            },'STDERR matching success'
+          );
+
+check_test( sub {
+            stderr_is(sub {
+                        local $, = " ";
+                        print STDERR "TEST", "OUT\n";
                       },
                       "TEST OUT\n",
                       'Testing STDERR'

--- a/t/stdout_is.t
+++ b/t/stdout_is.t
@@ -1,5 +1,5 @@
 use Test::Tester;
-use Test::More tests => 21;
+use Test::More tests => 35;
 use Test::Output;
 
 use strict;
@@ -8,6 +8,35 @@ use warnings;
 check_test( sub {
             stdout_is(sub {
                         print "TEST OUT\n";
+                      },
+                      "TEST OUT\n",
+                      'Testing STDOUT'
+                    )
+            },{
+              ok => 1,
+              name => 'Testing STDOUT',
+              diag => '',
+            },'STDOUT matches success'
+          );
+
+check_test( sub {
+            stdout_is(sub {
+                        print "TEST", " ", "OUT", "\n";
+                      },
+                      "TEST OUT\n",
+                      'Testing STDOUT'
+                    )
+            },{
+              ok => 1,
+              name => 'Testing STDOUT',
+              diag => '',
+            },'STDOUT matches success'
+          );
+
+check_test( sub {
+            stdout_is(sub {
+                        local $, = " ";
+                        print "TEST", "OUT\n";
                       },
                       "TEST OUT\n",
                       'Testing STDOUT'


### PR DESCRIPTION
<code>% perl -Mstrict -MTest::More=no_plan -MTest::Output -we 'stdout_is(sub{ print "foo","bar",$/ }, "foobar\n");'</code>

The one-liner above works fine with Test::Output 0.16, but with 0.16_02 it fails with the following output:

<pre>not ok 1
#   Failed test at -e line 1.
# STDOUT is:
# foo:::sbar:::s
# 
# not:
# foobar
# 
# as expected
1..1
# Looks like you failed 1 test of 1.</pre>

It's due to this line in lib/Test/Output/Tie.pm:

<pre><code>$$self .= join(':::s', @_);</code></pre>


This <code>':::s'</code> probably is a typo for <code>''</code>, but additionally it should be better to use the variable <code>$,</code> ($OUTPUT_FIELD_SEPARATOR) if it's set, I think.
I fixed it and added the test case.

Thanks,
