### PR TITLE
Support close in STDOUT/STDERR

### DIFF
--- a/lib/Test/Output/Tie.pm
+++ b/lib/Test/Output/Tie.pm
@@ -87,6 +87,12 @@ sub read {
     return $data;
 }
 
+=item CLOSE
+
+=cut
+
+sub CLOSE {}
+
 =back
 
 =head1 AUTHOR

--- a/t/close.t
+++ b/t/close.t
@@ -1,0 +1,16 @@
+#!perl
+
+use Test::Tester;
+use Test::More tests => 1;
+use Test::Output;
+
+use strict;
+use warnings;
+
+eval {
+    stdout_is(
+        sub { close STDOUT; },
+        '',
+        "The close doesn't cause expcetions"
+    );
+};


### PR DESCRIPTION
Closing STDOUT in END {} is common practice.
