### PR TITLE
Proof of Concept - Tee output on request

### DIFF
--- a/lib/Test/Output.pm
+++ b/lib/Test/Output.pm
@@ -6,7 +6,7 @@ use warnings;
 use strict;
 
 use Test::Builder;
-use Capture::Tiny qw/capture capture_stdout capture_stderr capture_merged/;
+use Capture::Tiny qw/capture capture_stdout capture_stderr capture_merged tee_merged/;
 
 use Exporter qw(import);
 
@@ -863,11 +863,12 @@ captures them. C<combined_from()> is equivalent to using C<< 2>&1 >> in UNIX.
 sub combined_from (&) {
   my $test = shift;
 
-  my $combined = capture_merged {
+  my $func = $ENV{PERL5_TEST_OUTPUT_TEE} ? 'tee_merged' : 'capture_merged';
+  my $combined = __PACKAGE__->can($func)->(sub {
     select( ( select(STDOUT), $| = 1 )[0] );
     select( ( select(STDERR), $| = 1 )[0] );
     $test->();
-  };
+  });
 
   return $combined;
 }

--- a/t/tee-example.t
+++ b/t/tee-example.t
@@ -1,0 +1,17 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More;
+use v5.10;
+
+use Test::Output qw/ combined_like /;
+
+sub multiply {
+    my ($input) = @_;
+    say "Calculating $input * 2";
+    return $input * 2;
+}
+
+combined_like { multiply(23) } qr/Calculating 23 \* 2/, 'multiply works';
+
+done_testing;


### PR DESCRIPTION
See #16

For debugging purposes, this allows to additionally see any captured output by setting `PERL5_TEST_OUTPUT_TEE=1`.
I only implemented it for `combined_like / combined_from`.

I added an example test script:
```
% prove -l t/tee-example.t -v
ok 1 - multiply works
1..1
ok
All tests successful.
Files=1, Tests=1,  0 wallclock secs ( 0.01 usr  0.01 sys +  0.05 cusr  0.01 csys =  0.08 CPU)
Result: PASS

% PERL5_TEST_OUTPUT_TEE=1 prove -l t/tee-example.t -v
t/tee-example.t .. 
Calculating 23 * 2
ok 1 - multiply works
1..1
ok
All tests successful.
Files=1, Tests=1,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.05 cusr  0.02 csys =  0.10 CPU)
Result: PASS
```

It could also be used locally for just one subtest:
```perl
subtest something => sub {
    local $ENV{PERL5_TEST_OUTPUT_TEE} = 1;
    combined_like {} ...;
};
```